### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/Common.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/Common.java
@@ -27,6 +27,9 @@ public class Common {
     public final static String KEY_NETWORK = "AD_NETWORKS";
     public final static String KEY_BLOCK_NUM = "BLOCK_NUM";
 
+    private Common() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static String getModeString(MainFragment.FragmentMode mode) {
         switch (mode) {

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/ApiBlocking.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/ApiBlocking.java
@@ -21,6 +21,11 @@ import static de.robv.android.xposed.XposedHelpers.findClass;
  * Created by fatminmin on 2015/10/27.
  */
 public class ApiBlocking {
+    
+    private ApiBlocking() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static void handle(final String packageName, final XC_LoadPackage.LoadPackageParam lpparam, final boolean removeAd) {
 
         Class<?> activity = XposedHelpers.findClass("android.app.Application", lpparam.classLoader);

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/HostBlock.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/HostBlock.java
@@ -16,6 +16,10 @@ public class HostBlock {
 
     private static final String UNABLE_TO_RESOLVE_HOST = "Unable to resolve host";
 
+    private HostBlock() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static void block(XC_LoadPackage.LoadPackageParam lpparam) {
 
         Class<?> inetAddrClz = XposedHelpers.findClass("java.net.InetAddress", lpparam.classLoader);

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
@@ -15,6 +15,11 @@ import tw.fatminmin.xposed.minminguard.Main;
  * Created by fatminmin on 2015/10/27.
  */
 public class NameBlocking {
+    
+    private NameBlocking() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     private static boolean matchBannerName(String clazzName, String banner, String bannerPrefix) {
         if(banner != null && banner.equals(clazzName)) {
             return true;

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/UrlFiltering.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/UrlFiltering.java
@@ -15,6 +15,11 @@ import tw.fatminmin.xposed.minminguard.Main;
 
 public class UrlFiltering {
     private static boolean adExist = false;
+
+    private UrlFiltering() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     static public boolean removeWebViewAds(final String packageName, LoadPackageParam lpparam) {
 
         try {

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/Util.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/Util.java
@@ -32,6 +32,10 @@ public class Util {
     final static public String TAG = "MinMinGuard";
     final static public String PACKAGE = "tw.fatminmin.xposed.minminguard";
 
+    private Util() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     static public Boolean xposedEnabled() {
         return false;
     }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/NextMedia.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/NextMedia.java
@@ -9,6 +9,11 @@ import tw.fatminmin.xposed.minminguard.blocker.ApiBlocking;
 public class NextMedia  {
 
     public static final String AD_UTILS = "com.nextmediatw.data.AdUtils";
+
+    private NextMedia() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     static public void handleLoadPackage(final String packageName, XC_LoadPackage.LoadPackageParam lpparam, boolean removeAd) {
         ApiBlocking.blockAdFunctionWithResult(packageName, AD_UTILS, "skipAd", Boolean.valueOf(true), lpparam, removeAd);
     }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/OneWeather.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/OneWeather.java
@@ -11,6 +11,11 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 public class OneWeather {
     private static final String LAYOUT = "com.handmark.expressweather";
+
+    private OneWeather() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static boolean handleLoadPackage(final String packageName, LoadPackageParam lpparam, final boolean removeAd) {
         try {
             Class<?> adView = XposedHelpers.findClass("com.handmark.expressweather.billing.BillingUtils", lpparam.classLoader);

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/PeriodCalendar.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/PeriodCalendar.java
@@ -13,6 +13,10 @@ public class PeriodCalendar {
 
     public static String pkgName = "com.popularapp.periodcalendar";
 
+    private PeriodCalendar() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static void handleInitPackageResources(XC_InitPackageResources.InitPackageResourcesParam resparam) {
         if(!resparam.packageName.equals(pkgName)) {
             return;

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/Train.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/Train.java
@@ -12,6 +12,10 @@ public class Train {
 	
 	
 	protected static String pkg = "idv.nightgospel.TWRailScheduleLookUp";
+
+	private Train() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 	
 	public static void handleLoadPackage(LoadPackageParam lpparam) {
 		if(!lpparam.packageName.equals(pkg))

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/_2chMate.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/_2chMate.java
@@ -10,6 +10,11 @@ import tw.fatminmin.xposed.minminguard.blocker.Util;
 import android.view.View;
 
 public class _2chMate {
+
+    private _2chMate() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static boolean handleLoadPackage(final String packageName, LoadPackageParam lpparam, final boolean removeAd) {
         if (!packageName.equals("jp.co.airfront.android.a2chMate")) {
             return false;

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/UIUtils.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/UIUtils.java
@@ -9,6 +9,11 @@ import android.content.Intent;
  * Created by fatminmin on 2015/10/25.
  */
 public class UIUtils {
+
+    private UIUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     static public void restartApp(Context context, String packageName)
     {
         ActivityManager am = (ActivityManager) context.getSystemService(Activity.ACTIVITY_SERVICE);

--- a/generator/src/main/java/tw/fatminmin/greendao/MyClass.java
+++ b/generator/src/main/java/tw/fatminmin/greendao/MyClass.java
@@ -7,6 +7,11 @@ import de.greenrobot.daogenerator.Entity;
 import de.greenrobot.daogenerator.Schema;
 
 public class MyClass {
+
+    private MyClass() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static void main(String args[]) {
         System.out.println("Working Directory = " + System.getProperty("user.dir"));
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat