### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/ApiBlocking.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/ApiBlocking.java
@@ -20,7 +20,7 @@ import static de.robv.android.xposed.XposedHelpers.findClass;
 /**
  * Created by fatminmin on 2015/10/27.
  */
-public class ApiBlocking {
+public final class ApiBlocking {
     
     private ApiBlocking() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/HostBlock.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/HostBlock.java
@@ -12,7 +12,7 @@ import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 import tw.fatminmin.xposed.minminguard.Main;
 
-public class HostBlock {
+public final class HostBlock {
 
     private static final String UNABLE_TO_RESOLVE_HOST = "Unable to resolve host";
 

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
@@ -14,7 +14,7 @@ import tw.fatminmin.xposed.minminguard.Main;
 /**
  * Created by fatminmin on 2015/10/27.
  */
-public class NameBlocking {
+public final class NameBlocking {
     
     private NameBlocking() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/UrlFiltering.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/UrlFiltering.java
@@ -13,7 +13,7 @@ import de.robv.android.xposed.XposedHelpers.ClassNotFoundError;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 import tw.fatminmin.xposed.minminguard.Main;
 
-public class UrlFiltering {
+public final class UrlFiltering {
     private static boolean adExist = false;
 
     private UrlFiltering() throws InstantiationException {

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/Util.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/Util.java
@@ -24,7 +24,7 @@ import de.robv.android.xposed.XposedHelpers;
 import tw.fatminmin.xposed.minminguard.Common;
 import tw.fatminmin.xposed.minminguard.Main;
 
-public class Util {
+public final class Util {
     
     public static XSharedPreferences pref;
     

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/NextMedia.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/NextMedia.java
@@ -6,7 +6,7 @@ import tw.fatminmin.xposed.minminguard.blocker.ApiBlocking;
 /**
  * Created by fatminmin on 2016/2/7.
  */
-public class NextMedia  {
+public final class NextMedia  {
 
     public static final String AD_UTILS = "com.nextmediatw.data.AdUtils";
 

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/OneWeather.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/OneWeather.java
@@ -9,7 +9,7 @@ import de.robv.android.xposed.callbacks.XC_InitPackageResources.InitPackageResou
 import de.robv.android.xposed.callbacks.XC_LayoutInflated;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
-public class OneWeather {
+public final class OneWeather {
     private static final String LAYOUT = "com.handmark.expressweather";
 
     private OneWeather() throws InstantiationException {

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/PeriodCalendar.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/PeriodCalendar.java
@@ -9,7 +9,7 @@ import tw.fatminmin.xposed.minminguard.Main;
 /**
  * Created by fatminmin on 2015/10/30.
  */
-public class PeriodCalendar {
+public final class PeriodCalendar {
 
     public static String pkgName = "com.popularapp.periodcalendar";
 

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/Train.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/Train.java
@@ -8,7 +8,7 @@ import de.robv.android.xposed.callbacks.XC_InitPackageResources.InitPackageResou
 import de.robv.android.xposed.callbacks.XC_LayoutInflated;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
-public class Train {
+public final class Train {
 	
 	
 	protected static String pkg = "idv.nightgospel.TWRailScheduleLookUp";

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/_2chMate.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/custom_mod/_2chMate.java
@@ -9,7 +9,7 @@ import tw.fatminmin.xposed.minminguard.blocker.Util;
 
 import android.view.View;
 
-public class _2chMate {
+public final class _2chMate {
 
     private _2chMate() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/UIUtils.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/UIUtils.java
@@ -8,7 +8,7 @@ import android.content.Intent;
 /**
  * Created by fatminmin on 2015/10/25.
  */
-public class UIUtils {
+public final class UIUtils {
 
     private UIUtils() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/adapter/ModeFragmentAdapter.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/adapter/ModeFragmentAdapter.java
@@ -10,7 +10,7 @@ import tw.fatminmin.xposed.minminguard.ui.fragments.MainFragment;
 /**
  * Created by fatminmin on 4/21/16.
  */
-public class ModeFragmentAdapter extends FragmentPagerAdapter {
+public final class ModeFragmentAdapter extends FragmentPagerAdapter {
 
     static final int PAGE_COUNT = 3;
     private String[] mTabTitles = new String[] { "AUTO", "Blacklist", "Whitelist" };

--- a/generator/src/main/java/tw/fatminmin/greendao/MyClass.java
+++ b/generator/src/main/java/tw/fatminmin/greendao/MyClass.java
@@ -6,7 +6,7 @@ import de.greenrobot.daogenerator.DaoGenerator;
 import de.greenrobot.daogenerator.Entity;
 import de.greenrobot.daogenerator.Schema;
 
-public class MyClass {
+public final class MyClass {
 
     private MyClass() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without public constructors should be final

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=S2974

Please let me know if you have any questions.

M-Ezzat