### PR TITLE
Multiple quality improvements - squid:S1213, squid:SwitchLastCaseIsDe…

### DIFF
--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/Common.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/Common.java
@@ -39,6 +39,8 @@ public class Common {
                 return Common.VALUE_MODE_BLACKLIST;
             case WHITELIST:
                 return Common.VALUE_MODE_WHITELIST;
+            default:
+                break;
         }
         return Common.VALUE_MODE_BLACKLIST;
     }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/orm/DaoMaster.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/orm/DaoMaster.java
@@ -17,6 +17,11 @@ import tw.fatminmin.xposed.minminguard.orm.AppDataDao;
 public class DaoMaster extends AbstractDaoMaster {
     public static final int SCHEMA_VERSION = 1;
 
+    public DaoMaster(SQLiteDatabase db) {
+        super(db, SCHEMA_VERSION);
+        registerDaoClass(AppDataDao.class);
+    }
+
     /** Creates underlying database table using DAOs. */
     public static void createAllTables(SQLiteDatabase db, boolean ifNotExists) {
         AppDataDao.createTable(db, ifNotExists);
@@ -54,11 +59,6 @@ public class DaoMaster extends AbstractDaoMaster {
         }
     }
 
-    public DaoMaster(SQLiteDatabase db) {
-        super(db, SCHEMA_VERSION);
-        registerDaoClass(AppDataDao.class);
-    }
-    
     public DaoSession newSession() {
         return new DaoSession(db, IdentityScopeType.Session, daoConfigMap);
     }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/MainActivity.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/MainActivity.java
@@ -52,6 +52,8 @@ public class MainActivity extends AppCompatActivity {
                     startActivity(new Intent(Intent.ACTION_VIEW,
                             Uri.parse("http://fatminmin.com/pages/minminguard.html")));
                     break;
+                default:
+                    break;
             }
             return true;
         }
@@ -131,6 +133,8 @@ public class MainActivity extends AppCompatActivity {
                 break;
             case Common.VALUE_MODE_WHITELIST:
                 mViewPager.setCurrentItem(2);
+                break;
+            default:
                 break;
         }
     }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/fragments/MainFragment.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/fragments/MainFragment.java
@@ -54,6 +54,8 @@ public class MainFragment extends Fragment {
     private List<PackageInfo> mAppList;
     private SharedPreferences mPref;
 
+    public MainFragment() {
+    }
 
     private final View.OnClickListener btnModeClick = new View.OnClickListener() {
         @Override
@@ -72,9 +74,6 @@ public class MainFragment extends Fragment {
         args.putInt("mode", mode.ordinal());
         fragment.setArguments(args);
         return fragment;
-    }
-
-    public MainFragment() {
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat