### PR TITLE
Check root view before clearing ads

### DIFF
--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
@@ -147,7 +147,9 @@ public final class NameBlocking {
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                 View root = (View) param.getResult();
-                clearAdViewInLayout(pkgName, root);
+                if(root != null){
+                    clearAdViewInLayout(pkgName, root);
+                }
             }
         });
 


### PR DESCRIPTION
Make sure the inflated root view is not null.
Issue reproduced with a weather widget view on Mi 5s/6.0.1.