### PR TITLE
Fix NullPointerExceptions when using Youtube app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,11 +60,11 @@ android {
 dependencies {
     provided 'de.robv.android.xposed:api:82'
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:support-v4:23.0.1'
-    compile 'com.android.support:cardview-v7:+'
-    compile 'com.android.support:recyclerview-v7:+'
-    compile 'com.android.support:design:+'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:support-v4:23.4.0'
+    compile 'com.android.support:cardview-v7:23.4.0'
+    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile 'com.android.support:design:23.4.0'
     compile 'com.github.paolorotolo:appintro:3.2.0'
     compile 'de.greenrobot:greendao:2.0.0'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/blocker/NameBlocking.java
@@ -105,6 +105,9 @@ public final class NameBlocking {
             @Override
             protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                 View view = (View) param.args[0];
+                if(view == null) {
+                    return;
+                }
                 if (isAdView(view.getContext(), pkgName, view)) {
                     Main.removeAdView(view, pkgName, true);
                 }
@@ -113,6 +116,9 @@ public final class NameBlocking {
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                 View view = (View) param.args[0];
+                if(view == null) {
+                    return;
+                }
                 if (isAdView(view.getContext(), pkgName, view)) {
                     Util.log(pkgName, "NameBasedBlocking after addView: " + view.getClass().getName());
                     Main.removeAdView(view, pkgName, true);


### PR DESCRIPTION
When using MinMinGuard 2.0beta5 with set to Auto together with Youtube app version 12.44.53, the Xposed log would be spammed with NPEs occurring in the NameBlocking hook.

This fixes it for me.