### PR TITLE
Fix MinMinGuard for Android 11+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ gen/
 .gradle/
 build/
 actionbarsherlock/build/
+app/release/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,17 @@
-buildscript {
-    repositories {
-        maven { url 'https://maven.fabric.io/public' }
-    }
-
-    dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
-    }
-}
+//buildscript {
+//    repositories {
+//        maven { url 'https://maven.fabric.io/public' }
+//    }
+//
+//    dependencies {
+//        classpath 'io.fabric.tools:gradle:1.+'
+//    }
+//}
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
+//apply plugin: 'io.fabric'
 
 repositories {
-    maven { url 'https://maven.fabric.io/public' }
+//    maven { url 'https://maven.fabric.io/public' }
     maven { url 'https://jitpack.io' }
     jcenter()
     mavenCentral()
@@ -41,7 +41,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 71
-        versionName "2.1.1"
+        versionName "2.2.0"
     }
     buildTypes {
         release {
@@ -72,9 +72,9 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.github.apl-devs:appintro:v4.2.3'
     implementation 'de.greenrobot:greendao:2.0.0'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {
-        transitive = true
-    }
+//    implementation('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {
+//        transitive = true
+//    }
 
     //Glide
     implementation ('com.github.bumptech.glide:glide:4.9.0')

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,9 +44,14 @@
         <meta-data
                 android:name="xposeddescription"
                 android:value="Ads blocker"/>
-
         <meta-data
+                android:name="xposedsharedprefs"
+                android:value="true"/>
+        <meta-data
+                android:name="xposedscope"
+                android:value="android"/>
+        <!--<meta-data
                 android:name="io.fabric.ApiKey"
-                android:value="11b3bd0c3467e4848618141b36a73619c7ef4843"/>
+                android:value="11b3bd0c3467e4848618141b36a73619c7ef4843"/>-->
     </application>
 </manifest>

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/Common.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/Common.java
@@ -1,5 +1,7 @@
 package tw.fatminmin.xposed.minminguard;
 
+import android.content.Context;
+
 import tw.fatminmin.xposed.minminguard.ui.fragments.MainFragment;
 
 /**
@@ -56,4 +58,6 @@ public class Common
     {
         return pkgName + "_whitelist";
     }
+
+    public static Integer getPrefMode() { return Context.MODE_PRIVATE; }
 }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/MyApplication.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/MyApplication.java
@@ -1,8 +1,8 @@
 package tw.fatminmin.xposed.minminguard;
 
 import android.app.Application;
-import com.crashlytics.android.Crashlytics;
-import io.fabric.sdk.android.Fabric;
+//import com.crashlytics.android.Crashlytics;
+//import io.fabric.sdk.android.Fabric;
 
 /**
  * Created by fatminmin on 2015/10/3.
@@ -13,6 +13,6 @@ public class MyApplication extends Application
     public void onCreate()
     {
         super.onCreate();
-        Fabric.with(this, new Crashlytics());
+//        Fabric.with(this, new Crashlytics()); // Deprecated by defkev on 2022/5/10 -> Crashlytics is EOL since ~2019, migrate to Firebase???
     }
 }

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/MainActivity.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/MainActivity.java
@@ -111,8 +111,8 @@ public class MainActivity extends AppCompatActivity
         Context ctx = ContextCompat.createDeviceProtectedStorageContext(this);
         if (ctx == null) ctx = this;
 
-        uiPref = getSharedPreferences(Common.UI_PREFS, MODE_PRIVATE);
-        modPref = ctx.getSharedPreferences(Common.MOD_PREFS, MODE_PRIVATE);
+        uiPref = getSharedPreferences(Common.UI_PREFS, Common.getPrefMode());
+        modPref = ctx.getSharedPreferences(Common.MOD_PREFS, Common.getPrefMode());
 
         progressDialog = new ProgressDialog(this, R.style.MainSpinnerDialogStyle);
         progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/adapter/AppsAdapter.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/adapter/AppsAdapter.java
@@ -57,7 +57,7 @@ public class AppsAdapter extends RecyclerView.Adapter<AppsAdapter.ViewHolder>
         Context ctx = ContextCompat.createDeviceProtectedStorageContext(context);
         if (ctx == null) ctx = context;
 
-        mPref = ctx.getSharedPreferences(Common.MOD_PREFS, Context.MODE_PRIVATE);
+        mPref = ctx.getSharedPreferences(Common.MOD_PREFS, Common.getPrefMode());
 
         helper = new DaoMaster.DevOpenHelper(context, "mmg", null);
         db = helper.getWritableDatabase();

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/dialog/AppDetailDialogFragment.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/dialog/AppDetailDialogFragment.java
@@ -70,7 +70,7 @@ public class AppDetailDialogFragment extends DialogFragment
         Context ctx = ContextCompat.createDeviceProtectedStorageContext(getActivity());
         if (ctx == null) ctx = getActivity();
 
-        mPref = ctx.getSharedPreferences(Common.MOD_PREFS, Context.MODE_PRIVATE);
+        mPref = ctx.getSharedPreferences(Common.MOD_PREFS, Common.getPrefMode());
     }
 
     @Nullable

--- a/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/dialog/SettingsDialogFragment.java
+++ b/app/src/main/java/tw/fatminmin/xposed/minminguard/ui/dialog/SettingsDialogFragment.java
@@ -31,7 +31,7 @@ public class SettingsDialogFragment extends DialogFragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
     {
 
-        mUiPref = getActivity().getSharedPreferences(Common.UI_PREFS, Context.MODE_PRIVATE);
+        mUiPref = getActivity().getSharedPreferences(Common.UI_PREFS, Common.getPrefMode());
 
         getDialog().setTitle(R.string.action_settings);
 


### PR DESCRIPTION
Deprecate Crashlytics (EOL)
Add XSharedPreferences fix for LSposed API 93
Add permission fix for Android 11+ (API30)
Bump version to 2.2.0
Update .gitignore (add app/release/)

APK is available in the thread over at XDA:
https://forum.xda-developers.com/t/app-minminguard-for-android-11-zygisk-x-ed-lsposed-api-93.4502265/